### PR TITLE
Implement missing team args

### DIFF
--- a/main.go
+++ b/main.go
@@ -223,6 +223,14 @@ This means that when the API changes
 		"--username", configs.ItunesconUser,
 		"--app", configs.AppID,
 	}
+	
+	if configs.TeamID != "" {
+		args = append(args, "--team_id", configs.TeamID)
+	}
+	
+	if configs.TeamName != "" {
+		args = append(args, "--team_name", configs.TeamName)
+	}
 
 	if configs.IpaPath != "" {
 		args = append(args, "--ipa", configs.IpaPath)


### PR DESCRIPTION
Currently, this step accepts the team_id and team_name inputs, but won't add the necessary arguments to the deliver command.

This pull request adds the two missing arguments (unless blank).