### PR TITLE
add AppPassword to make use of application-specific passwords

### DIFF
--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ type ConfigsModel struct {
 
 	ItunesconUser string
 	Password      string
+	AppPassword   string
 
 	AppID           string
 	BundleID        string
@@ -48,6 +49,7 @@ func createConfigsModelFromEnvs() ConfigsModel {
 
 		ItunesconUser: os.Getenv("itunescon_user"),
 		Password:      os.Getenv("password"),
+		AppPassword:   os.Getenv("app_password"),
 
 		AppID:           os.Getenv("app_id"),
 		BundleID:        os.Getenv("bundle_id"),
@@ -72,6 +74,7 @@ func (configs ConfigsModel) print() {
 
 	log.Printf("- ItunesconUser: %s", configs.ItunesconUser)
 	log.Printf("- Password: %s", input.SecureInput(configs.Password))
+	log.Printf("- AppPassword: %s", input.SecureInput(configs.AppPassword))
 
 	log.Printf("- AppID: %s", configs.AppID)
 	log.Printf("- BundleID: %s", configs.BundleID)
@@ -355,6 +358,10 @@ This means that when the API changes
 	envs := []string{
 		fmt.Sprintf("DELIVER_PASSWORD=%s", configs.Password),
 	}
+
+	if configs.AppPassword != "" {
+        envs = append(envs, fmt.Sprintf("FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD=%s", configs.AppPassword))
+    }
 
 	args := []string{
 		"deliver",

--- a/step.yml
+++ b/step.yml
@@ -93,6 +93,10 @@ inputs:
       summary: ""
       description: |-
         an Application specific password for the Apple ID.
+
+        **Note:** Application specific passwords can be created on the
+        [AppleID Website](https://appleid.apple.com). It can be used to
+        surpass Two Factor Authentication.
       is_required: false
   - app_id: ""
     opts:

--- a/step.yml
+++ b/step.yml
@@ -87,6 +87,13 @@ inputs:
         to something with only
         alphanumeric characters.
       is_required: true
+  - app_password: ""
+    opts:
+      title: "iTunes Connect: Application Specific Password"
+      summary: ""
+      description: |-
+        an Application specific password for the Apple ID.
+      is_required: false
   - app_id: ""
     opts:
       title: "iTunes Connect: App Apple ID"


### PR DESCRIPTION
Support Apple's `application-specific password` to workaround 2FA

See: https://github.com/bitrise-io/steps-deploy-to-itunesconnect-deliver/issues/33#issuecomment-350059732

Fixes #33 