### PR TITLE
Fix "ERROR: Could not start delivery: all transports failed diagnostics"

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -19,6 +19,7 @@ app:
   - ITUNES_CONNECT_APP_SPECIFIC_PASSWORD: $ITUNES_CONNECT_APP_SPECIFIC_PASSWORD
   - ITUNES_CONNECT_TEAM_NAME: $ITUNES_CONNECT_TEAM_NAME
   - ITUNES_CONNECT_APP_ID: $ITUNES_CONNECT_APP_ID
+  - ITMS_UPLOAD_OPTIONS: $ITMS_UPLOAD_OPTIONS
 
 workflows:
   # ----------------------------------------------------------------
@@ -70,6 +71,7 @@ workflows:
         - app_password: $ITUNES_CONNECT_APP_SPECIFIC_PASSWORD
         - team_name: $ITUNES_CONNECT_TEAM_NAME
         - app_id: $ITUNES_CONNECT_APP_ID
+        - itms_options: $ITMS_UPLOAD_OPTIONS
         - submit_for_review: "no"
         - skip_metadata: "no"
         - skip_screenshots: "no"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -19,7 +19,6 @@ app:
   - ITUNES_CONNECT_APP_SPECIFIC_PASSWORD: $ITUNES_CONNECT_APP_SPECIFIC_PASSWORD
   - ITUNES_CONNECT_TEAM_NAME: $ITUNES_CONNECT_TEAM_NAME
   - ITUNES_CONNECT_APP_ID: $ITUNES_CONNECT_APP_ID
-  - ITMS_UPLOAD_OPTIONS: $ITMS_UPLOAD_OPTIONS
 
 workflows:
   # ----------------------------------------------------------------
@@ -71,7 +70,6 @@ workflows:
         - app_password: $ITUNES_CONNECT_APP_SPECIFIC_PASSWORD
         - team_name: $ITUNES_CONNECT_TEAM_NAME
         - app_id: $ITUNES_CONNECT_APP_ID
-        - itms_options: $ITMS_UPLOAD_OPTIONS
         - submit_for_review: "no"
         - skip_metadata: "no"
         - skip_screenshots: "no"

--- a/main.go
+++ b/main.go
@@ -356,10 +356,9 @@ This means that when the API changes
 	}
 
 	envs := []string{
+		"DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS=\"-t DAV\"",
 		fmt.Sprintf("DELIVER_PASSWORD=%s", configs.Password),
 	}
-	
-	os.Setenv("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS", "-t DAV")
 	
 	if configs.AppPassword != "" {
         	envs = append(envs, fmt.Sprintf("FASTLANE_APPLE_APPLICATION_SPECIFIC_PASSWORD=%s", configs.AppPassword))

--- a/main.go
+++ b/main.go
@@ -37,7 +37,6 @@ type ConfigsModel struct {
 	TeamName        string
 	Platform        string
 	Options         string
-	ITMSOptions	string
 
 	GemfilePath     string
 	FastlaneVersion string
@@ -61,7 +60,6 @@ func createConfigsModelFromEnvs() ConfigsModel {
 		TeamName:        os.Getenv("team_name"),
 		Platform:        os.Getenv("platform"),
 		Options:         os.Getenv("options"),
-		ITMSOptions: os.Getenv("itms_options"),
 
 		GemfilePath:     os.Getenv("gemfile_path"),
 		FastlaneVersion: os.Getenv("fastlane_version"),
@@ -87,8 +85,6 @@ func (configs ConfigsModel) print() {
 	log.Printf("- TeamName: %s", configs.TeamName)
 	log.Printf("- Platform: %s", configs.Platform)
 	log.Printf("- Options: %s", configs.Options)
-	
-	log.Printf("- ITMS upload options: %s", configs.ITMSOptions)
 
 	log.Printf("- GemfilePath: %s", configs.GemfilePath)
 	log.Printf("- FastlaneVersion: %s", configs.FastlaneVersion)
@@ -362,12 +358,6 @@ This means that when the API changes
 	envs := []string{
 		"DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS=-t DAV",
 		fmt.Sprintf("DELIVER_PASSWORD=%s", configs.Password),
-	}
-	
-	if config.ITMSOptions == "" {
-		envs = append(envs, fmt.Sprintf("DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS=%s", configs.ITMSOptions))
-	} else {
-		envs = append(envs, "DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS=-t DAV")
 	}
 	
 	if configs.AppPassword != "" {


### PR DESCRIPTION
Fixes #30

Since the latest iTunes update (28/02/2018) the step is failing to upload the binaries, with the error described bellow.

As menitoned on Issue #30 setting the env `DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS` to `-t DAV` fixes the problem. Sice I'm working on a project without fastfile, I can't apply the fix suggested there. And, since, now, the step fails without this config, on this PR I'm setting this env

Error:

```
+------------------------------------------------------------------------------+
| (0) deploy-to-itunesconnect-deliver@2.12.0                                   |
+------------------------------------------------------------------------------+
| id: deploy-to-itunesconnect-deliver                                          |
| version: 2.12.0                                                              |
| collection: https://github.com/bitrise-io/bitrise-steplib.git                |
| toolkit: go                                                                  |
| time: 2018-03-01T07:55:16-08:00                                              |
+------------------------------------------------------------------------------+
|                                                                              |
INFO[07:55:16]  * [OK] Step dependency (go) installed, available. 
Configs:
- IpaPath: <IPA_PATH>
- PkgPath: 
- ItunesconUser: <USER>
- Password: ***
- AppPassword: 
- AppID: <APP_ID>
- BundleID: 
- SubmitForReview: no
- SkipMetadata: yes
- SkipScreenshots: yes
- TeamID: <TEAM_ID>
- TeamName: 
- Platform: ios
- Options: 
- GemfilePath: ./Gemfile
- FastlaneVersion: latest
Setup
fastlane version defined: latest, installing...
$ fastlane "-v"
fastlane installation at path:
/usr/local/lib/ruby/gems/2.4.0/gems/fastlane-2.83.0/bin/fastlane
-----------------------------
fastlane 2.83.0
Setup took 5.040519 seconds to complete
Deploy
**Note:** if your password
contains special characters
and you experience problems, please
consider changing your password
to something with only
alphanumeric characters.
**Be advised** log.Printf(that this
step uses a well maintained, open source tool which
uses *undocumented and unsupported APIs* (because the current
iTunes Connect platform does not have a documented and supported API)
to perform the deployment.
This means that when the API changes
**this step might fail until the tool is updated**.
$ fastlane "deliver" "--username" "<USER>" "--app" "<APP_ID>" "--team_id" "<TEAM_ID>" "--ipa" "<IPA_PATH>" "--skip_screenshots" "--skip_metadata" "--force" "--platform" "ios"
[07:55:27]: fastlane detected a Gemfile in the current directory
[07:55:27]: however it seems like you don't use `bundle exec`
[07:55:27]: to launch fastlane faster, please use
[07:55:27]: 
[07:55:27]: $ bundle exec fastlane deliver --username <USER> --app <APP_ID> --team_id <TEAM_ID> --ipa <IPA_PATH> --skip_screenshots --skip_metadata --force --platform ios
[07:55:27]: 
[07:55:27]: Get started using a Gemfile for fastlane https://docs.fastlane.tools/getting-started/ios/setup/#use-a-gemfile
[07:55:27]: Login to iTunes Connect (<USER>)
[07:55:29]: Login successful
+--------------------------------------+---------------------------------------------------------------+
|                                        deliver 2.83.0 Summary                                        |
+--------------------------------------+---------------------------------------------------------------+
| username                             | <USER>                                                        |
| team_id                              | <TEAM_ID>                                                     |
| ipa                                  | <IPA_PATH>                                                    |
| skip_screenshots                     | true                                                          |
| skip_metadata                        | true                                                          |
| force                                | true                                                          |
| platform                             | ios                                                           |
| app_identifier                       | <APP_BUNDLE_ID>                                               |
| screenshots_path                     | ./screenshots                                                 |
| metadata_path                        | ./metadata                                                    |
| app_version                          | 1.1.0                                                         |
| edit_live                            | false                                                         |
| skip_binary_upload                   | false                                                         |
| use_live_version                     | false                                                         |
| skip_app_version_update              | false                                                         |
| submit_for_review                    | false                                                         |
| automatic_release                    | false                                                         |
| phased_release                       | false                                                         |
| overwrite_screenshots                | false                                                         |
| run_precheck_before_submit           | true                                                          |
| precheck_default_rule_level          | warn                                                          |
| ignore_language_directory_validation | false                                                         |
| precheck_include_in_app_purchases    | true                                                          |
+--------------------------------------+---------------------------------------------------------------+
[07:55:30]: Making sure the latest version on iTunes Connect matches '1.1.0' from the ipa file...
[07:55:30]: '1.1.0' is the latest version on iTunes Connect
[07:55:32]: Uploading binary to iTunes Connect
[07:55:32]: Going to upload updated app to iTunes Connect
[07:55:32]: This might take a few minutes. Please don't interrupt the script.
[07:57:45]: [Transporter Error Output]: description length:5326193
[08:00:00]: [Transporter Error Output]: Could not start delivery: all transports failed diagnostics
[08:00:01]: Transporter transfer failed.
[08:00:01]: 
[08:00:01]: description length:5326193
Could not start delivery: all transports failed diagnostics
[08:00:01]: [iTMSTransporter] 	at com.signiant.interactivetransfer.engine.TransferEngine$2.run(TransferEngine.java:593)
[08:00:01]: [iTMSTransporter] 
[08:00:01]: [iTMSTransporter] [2018-03-01 08:00:00 PST] <Automatic reconnector> DEBUG: Received failed transfer notification; aborting
[08:00:01]: [iTMSTransporter] [2018-03-01 08:00:00 PST] <Automatic reconnector>  INFO: Scheduling automatic restart in 1 minute
[08:00:01]: [iTMSTransporter] [2018-03-01 08:00:00 PST] <main> ERROR: Could not start delivery: all transports failed diagnostics
[08:00:01]: [iTMSTransporter] 
[08:00:01]: [iTMSTransporter] 
[08:00:01]: [iTMSTransporter] 
[08:00:01]: [iTMSTransporter] Package Summary:
[08:00:01]: [iTMSTransporter]  
[08:00:01]: [iTMSTransporter] 1 package(s) were not uploaded because they had problems:
[08:00:01]: [iTMSTransporter] 	/tmp/1278944026.itmsp - Error Messages:
[08:00:01]: [iTMSTransporter] 		description length:5326193
[08:00:01]: [iTMSTransporter] 		Could not start delivery: all transports failed diagnostics
[08:00:01]: [iTMSTransporter] [2018-03-01 08:00:01 PST] <main> DBG-X: Returning 1
[08:00:01]: iTunes Transporter output above ^
[08:00:01]: description length:5326193
Could not start delivery: all transports failed diagnostics
Return status of iTunes Transporter was 1: description length:5326193
\nCould not start delivery: all transports failed diagnostics
The call to the iTMSTransporter completed with a non-zero exit status: 1. This indicates a failure.
Looking for related GitHub issues on fastlane/fastlane...
➡️  gym: error-reporting: codesigning failures in Check Dependencies aren't caught/noticed?
    https://github.com/fastlane/fastlane/issues/10081 [open] 7 💬
    4 weeks ago
➡️  [Transporter Error Output]: description length:3125638  followed by precheck/spaceship exception
    https://github.com/fastlane/fastlane/issues/11026 [open] 17 💬
    3 weeks ago
➡️  Pilot fails after successful upload: "Could not set changelog"
    https://github.com/fastlane/fastlane/issues/10088 [closed] 27 💬
    06 Jan 2018
and 65 more at: https://github.com/fastlane/fastlane/search?q=Could%20not%20upload%20binary%20to%20iTunes%20Connect.%20Check%20out%20the%20error%20above&type=Issues&utf8=✓
🔗  You can ⌘ + double-click on links to open them directly in your browser.
[08:00:02]: Sending crash report...
[08:00:02]: The stack trace is sanitized so no personal information is sent.
[08:00:02]: To see what we are sending, look here: /Users/vagrant/.fastlane/latest_crash.json
[08:00:02]: Learn more at https://docs.fastlane.tools/actions/opt_out_crash_reporting/
[08:00:02]: You can disable crash reporting by adding `opt_out_crash_reporting` at the top of your Fastfile
[!] Could not upload binary to iTunes Connect. Check out the error above
Deploy failed, error: exit status 1
|                                                                              |
+---+---------------------------------------------------------------+----------+
| x | deploy-to-itunesconnect-deliver@2.12.0 (exit code: 1)         | 289 sec  |
+---+---------------------------------------------------------------+----------+
| Issue tracker: ...om/bitrise-io/steps-deploy-to-itunesconnect-deliver/issues |
| Source: https://github.com/bitrise-io/steps-deploy-to-itunesconnect-deliver  |
+---+---------------------------------------------------------------+----------+
```